### PR TITLE
meta description issue when using md inline html

### DIFF
--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -5,7 +5,6 @@ html
     meta[http-equiv="X-UA-Compatible" content="IE=edge;chrome=1"]
     title
       = page_title
-    meta[name="description" content="#{page_description}"]
     = feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml", title: "Atom Feed"
     /[if lt IE 9]
       = javascript_include_tag "ie8"


### PR DESCRIPTION
Removed the entry `meta[name="description" content="#{page_description}"]`, due to the fact that any markdown with inline html will result in problem. I.e. the inline html will be rendered into the the layout itself, beside the yield content. Didn't find a better solution, by removing it. 
Inline HMTL like '`<div style=""></div>` etc. will result in a problem